### PR TITLE
git commit -m "fix: Add complete footer to buy-sell page

### DIFF
--- a/src/pages/BuySell.js
+++ b/src/pages/BuySell.js
@@ -885,7 +885,88 @@ function BuySell() {
         {activeSection === 'sell' && canSell && renderSellSection()}
         {activeSection === 'manage' && canSell && renderManageSection()}
       </div>
-      {/* ... footers ... */}
+
+      {/* First Footer Section */}
+      <div className="footer-section">
+        <div className="container">
+          <div className="footer-left">
+            <h2>Receive The Latest Offers & Updates Via Email</h2>
+            <form className="subscribe-form">
+              <input type="email" placeholder="Enter your email" required />
+              <button type="submit">Subscribe</button>
+            </form>
+          </div>
+
+          <div className="footer-center">
+            <div className="footer-column">
+              <h3>Categories</h3>
+              <ul>
+                <li><Link to="/browse?category=mathematics">Mathematics</Link></li>
+                <li><Link to="/browse?category=reference">Reference</Link></li>
+                <li><Link to="/browse?category=technology">Technology</Link></li>
+                <li><Link to="/browse?category=literature">Literature</Link></li>
+                <li><Link to="/browse?category=non-fiction">Non-Fiction</Link></li>
+              </ul>
+            </div>
+            <div className="footer-column">
+              <h3>Quick Links</h3>
+              <ul>
+                <li><Link to="/">Home</Link></li>
+                <li><Link to="/buy-sell?section=buy">Buy Books</Link></li>
+                <li><Link to="/buy-sell?section=sell">Sell Books</Link></li>
+                <li><Link to="/buy-sell?section=account">My Account</Link></li>
+                <li><Link to="/help">Help</Link></li>
+                <li><Link to="/contact">Contact</Link></li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="footer-right">
+            <div style={{textAlign: 'right'}}>
+              <Link to="/">
+                <img src="/logo.webp" alt="Site Logo" className="logo" />
+              </Link>
+              <span style={{textAlign: 'right'}}>PageTurn</span>
+            </div>
+            <p>Empowering education through affordable reading</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Second Footer Section */}
+      <div className="footer-bottom">
+        <div className="container">
+          <div className="footer-social">
+            <h4>Follow Us</h4>
+            <div className="social-icons">
+              <a href="#"><i className="fab fa-facebook-f"></i></a>
+              <a href="#"><i className="fab fa-instagram"></i></a>
+              <a href="#"><i className="fab fa-twitter"></i></a>
+              <a href="#"><i className="fab fa-linkedin-in"></i></a>
+            </div>
+          </div>
+
+          <div className="footer-center-logo">
+            <Link to="/">
+              <img src="/logo.webp" alt="Logo" />
+            </Link>
+            <span>PageTurn</span>
+          </div>
+
+          <div className="footer-payments">
+            <h4>We accept</h4>
+            <div className="payment-icons">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Visa_Inc._logo.svg" alt="Visa" />
+              <img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/Mastercard-logo.svg" alt="MasterCard" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Copyright Footer */}
+      <footer className="copyright-footer">
+        <p>&copy; 2025 PageTurn Bookstore. All rights reserved.</p>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
- Restore missing footer sections that were only placeholder comments
- Add newsletter subscription form with email input
- Include category navigation links (Mathematics, Reference, Technology, etc.)
- Add quick links section (Home, Buy Books, Sell Books, My Account, Help, Contact)
- Implement social media icons (Facebook, Instagram, Twitter, LinkedIn)
- Add payment method logos (Visa, MasterCard)
- Include copyright footer with 2025 PageTurn Bookstore branding

Footer Features:
- Three-section layout: newsletter/links, social/payments, copyright
- Responsive design with mobile-friendly stacking
- Brown gradient theme matching site design
- Interactive hover effects and proper navigation
- Professional styling with shine effects and dot patterns
- Consistent with other pages' footer implementation

Fixes: Footer now appears on all buy-sell page sections (Overview, Account, Buy, Sell, Manage)"